### PR TITLE
fix: kinsumers with same name crashed module

### DIFF
--- a/alarm_kinsumer.tf
+++ b/alarm_kinsumer.tf
@@ -1,7 +1,14 @@
-module "alarm_kinsumer" {
-  for_each = { for kinsumer in length(data.gosoline_application_metadata_definition.main) > 0 ? element(data.gosoline_application_metadata_definition.main, 0).metadata.cloud.aws.kinesis.kinsumers : [] : kinsumer.name => {
+locals {
+  kinsumers = { for kinsumer in length(data.gosoline_application_metadata_definition.main) > 0 ? element(data.gosoline_application_metadata_definition.main, 0).metadata.cloud.aws.kinesis.kinsumers : [] : kinsumer.name => {
     metadata = kinsumer
-  } }
+  }... }
+  kinsumer_keys = keys(local.kinsumers)
+  # There can be more than one kinsumer with the same name if the application is not configured correctly. The terraform module should not fail due to the app not being configured correctly though.
+  kinsumer_metadatas = { for kinsumer_key in local.kinsumer_keys : kinsumer_key => local.kinsumers[kinsumer_key][0] }
+}
+
+module "alarm_kinsumer" {
+  for_each = local.kinsumer_metadatas
 
   source  = "justtrackio/ecs-alarm-kinsumer/aws"
   version = "1.0.1"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
