### PR TITLE
fix: avoid elasticstack 0.15.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.67, != 6.14.0 |
-| <a name="requirement_elasticstack"></a> [elasticstack](#requirement\_elasticstack) | >= 0.11.4 |
+| <a name="requirement_elasticstack"></a> [elasticstack](#requirement\_elasticstack) | = 0.15.1 |
 | <a name="requirement_gosoline"></a> [gosoline](#requirement\_gosoline) | >= 1.0.0 |
 | <a name="requirement_grafana"></a> [grafana](#requirement\_grafana) | >= 1.40.1 |
 
@@ -14,7 +14,7 @@
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.67, != 6.14.0 |
-| <a name="provider_elasticstack"></a> [elasticstack](#provider\_elasticstack) | >= 0.11.4 |
+| <a name="provider_elasticstack"></a> [elasticstack](#provider\_elasticstack) | = 0.15.1 |
 | <a name="provider_gosoline"></a> [gosoline](#provider\_gosoline) | >= 1.0.0 |
 | <a name="provider_grafana"></a> [grafana](#provider\_grafana) | >= 1.40.1 |
 

--- a/versions.tf
+++ b/versions.tf
@@ -17,7 +17,7 @@ terraform {
 
     elasticstack = {
       source  = "elastic/elasticstack"
-      version = ">= 0.11.4"
+      version = "= 0.15.1"
     }
   }
 


### PR DESCRIPTION
## Description
Exclude elasticstack 0.15.2 from the provider constraint and update generated docs.

## Motivation and Context
OpenTofu Workspaces fail with `Provider produced inconsistent result after apply` after elasticstack 0.15.2.

## Breaking Changes
None.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [ ] I have executed `pre-commit run -a` on my pull request