### PR TITLE
fix: normalize ES index template provider state

### DIFF
--- a/elasticsearch.tf
+++ b/elasticsearch.tf
@@ -24,6 +24,9 @@ locals {
     tag                 = { type = "keyword" }
   }
   mapping_properties = merge(local.default_mappings, var.elasticsearch_index_template.additional_fields)
+  index_template_routing_include = var.elasticsearch_index_template.node_name == "*" ? {} : {
+    _name = var.elasticsearch_index_template.node_name
+  }
 }
 
 module "elasticsearch_label" {
@@ -51,29 +54,26 @@ resource "elasticstack_elasticsearch_index_template" "default" {
           name = elasticstack_elasticsearch_index_lifecycle.default[0].name
         }
         codec              = "default"
-        number_of_shards   = var.elasticsearch_index_template.number_of_shards
-        number_of_replicas = var.elasticsearch_index_template.number_of_replicas
+        number_of_shards   = tostring(var.elasticsearch_index_template.number_of_shards)
+        number_of_replicas = tostring(var.elasticsearch_index_template.number_of_replicas)
         query = {
           default_field = ["message"]
         }
         routing = {
           allocation = {
-            include = {
-              _name = var.elasticsearch_index_template.node_name
-            }
+            include = local.index_template_routing_include
           }
         }
       }
     })
     mappings = jsonencode({
-      dynamic = true
+      dynamic = "true"
       dynamic_date_formats = [
         "strict_date_optional_time",
         "yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z"
       ]
       date_detection    = true
       numeric_detection = false
-      dynamic_templates = []
       properties        = local.mapping_properties
     })
   }


### PR DESCRIPTION
## Goal ✨

Fix the gosoline monitoring OpenTofu reconciliation failure on Elasticsearch 9 by making the generated index template match elasticstack provider read-back.

## Scope 🔎

- Render shard and replica counts as strings in the index template settings JSON.
- Avoid sending the no-op `_name = "*"` routing allocation value while preserving explicit non-default `node_name` support.
- Match Elasticsearch/provider mapping normalization by using `dynamic = "true"` and omitting the empty `dynamic_templates` list.

## Done ✅

- `mise exec -- terraform fmt`
- `mise exec -- terraform init -backend=false`
- `mise exec -- terraform validate`