### PR TITLE
fixes: pass alarm_enabled var down to alarm modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@
 
 | Name | Type |
 |------|------|
-| [elasticstack_elasticsearch_index_lifecycle.default](https://registry.terraform.io/providers/elastic/elasticstack/latest/docs/resources/elasticsearch_index_lifecycle) | resource |
-| [elasticstack_elasticsearch_index_template.default](https://registry.terraform.io/providers/elastic/elasticstack/latest/docs/resources/elasticsearch_index_template) | resource |
-| [elasticstack_kibana_data_view.default](https://registry.terraform.io/providers/elastic/elasticstack/latest/docs/resources/kibana_data_view) | resource |
+| [elasticstack_elasticsearch_index_lifecycle.default](https://registry.terraform.io/providers/elastic/elasticstack/0.15.1/docs/resources/elasticsearch_index_lifecycle) | resource |
+| [elasticstack_elasticsearch_index_template.default](https://registry.terraform.io/providers/elastic/elasticstack/0.15.1/docs/resources/elasticsearch_index_template) | resource |
+| [elasticstack_kibana_data_view.default](https://registry.terraform.io/providers/elastic/elasticstack/0.15.1/docs/resources/kibana_data_view) | resource |
 | [grafana_dashboard.main](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/dashboard) | resource |
 | [grafana_data_source.elasticsearch](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/data_source) | resource |
 | [aws_sns_topic.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/sns_topic) | data source |

--- a/alarm_consumer.tf
+++ b/alarm_consumer.tf
@@ -21,6 +21,7 @@ module "alarm_consumer" {
     }
   }
 
+  enabled = var.alarm_enabled
   source  = "justtrackio/ecs-alarm-consumer/aws"
   version = "1.2.1"
 

--- a/alarm_gateway.tf
+++ b/alarm_gateway.tf
@@ -28,6 +28,7 @@ module "alarm_gateway" {
     for handler in local.handlers : "${handler.server_name}:${handler.method}:${handler.path}" => handler
   }
 
+  enabled = var.alarm_enabled
   source  = "justtrackio/ecs-alarm-gateway/aws"
   version = "1.4.1"
 

--- a/alarm_kinsumer.tf
+++ b/alarm_kinsumer.tf
@@ -22,6 +22,7 @@ locals {
 module "alarm_kinsumer" {
   for_each = local.kinsumer_metadatas
 
+  enabled = var.alarm_enabled
   source  = "justtrackio/ecs-alarm-kinsumer/aws"
   version = "1.1.2"
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
